### PR TITLE
Obscure Tooltips 1.20/1.21 版本翻译更新与命名空间适配

### DIFF
--- a/projects/assets/obscure-tooltips/1.20-fabric/obscure_tooltips/packer-policy.json
+++ b/projects/assets/obscure-tooltips/1.20-fabric/obscure_tooltips/packer-policy.json
@@ -1,0 +1,6 @@
+[
+    {
+        "type": "indirect",
+        "source": "projects/assets/obscure-tooltips/1.20/obscure_tooltips"
+    }
+]

--- a/projects/assets/obscure-tooltips/1.20/minecraft/lang/en_us.json
+++ b/projects/assets/obscure-tooltips/1.20/minecraft/lang/en_us.json
@@ -1,6 +1,0 @@
-{
-  "rarity.common.name": "Common",
-  "rarity.uncommon.name": "Uncommon",
-  "rarity.rare.name": "Rare",
-  "rarity.epic.name": "Epic"
-}

--- a/projects/assets/obscure-tooltips/1.20/minecraft/lang/zh_cn.json
+++ b/projects/assets/obscure-tooltips/1.20/minecraft/lang/zh_cn.json
@@ -1,6 +1,0 @@
-{
-  "rarity.common.name": "常见",
-  "rarity.uncommon.name": "少见",
-  "rarity.rare.name": "稀有",
-  "rarity.epic.name": "史诗"
-}

--- a/projects/assets/obscure-tooltips/1.20/obscure_tooltips/lang/en_us.json
+++ b/projects/assets/obscure-tooltips/1.20/obscure_tooltips/lang/en_us.json
@@ -1,0 +1,8 @@
+{
+  "rarity.common": "Common",
+  "rarity.uncommon": "Uncommon",
+  "rarity.rare": "Rare",
+  "rarity.epic": "Epic",
+  "toast.obscure_tooltips.hint_1": "Enable the built-in %s pack",
+  "toast.obscure_tooltips.hint_2": "It contains animated effects and styles!"
+}

--- a/projects/assets/obscure-tooltips/1.20/obscure_tooltips/lang/zh_cn.json
+++ b/projects/assets/obscure-tooltips/1.20/obscure_tooltips/lang/zh_cn.json
@@ -1,0 +1,8 @@
+{
+  "rarity.common": "常见",
+  "rarity.uncommon": "少见",
+  "rarity.rare": "稀有",
+  "rarity.epic": "史诗",
+  "toast.obscure_tooltips.hint_1": "启用内置%s资源包",
+  "toast.obscure_tooltips.hint_2": "它包含动画效果和样式！"
+}

--- a/projects/assets/obscure-tooltips/1.21-fabric/obscure_tooltips/packer-policy.json
+++ b/projects/assets/obscure-tooltips/1.21-fabric/obscure_tooltips/packer-policy.json
@@ -1,0 +1,6 @@
+[
+    {
+        "type": "indirect",
+        "source": "projects/assets/obscure-tooltips/1.21/obscure_tooltips"
+    }
+]

--- a/projects/assets/obscure-tooltips/1.21/obscure_tooltips/lang/en_us.json
+++ b/projects/assets/obscure-tooltips/1.21/obscure_tooltips/lang/en_us.json
@@ -1,0 +1,8 @@
+{
+  "rarity.common": "Common",
+  "rarity.uncommon": "Uncommon",
+  "rarity.rare": "Rare",
+  "rarity.epic": "Epic",
+  "toast.obscure_tooltips.hint_1": "Enable the built-in %s pack",
+  "toast.obscure_tooltips.hint_2": "It contains animated effects and styles!"
+}

--- a/projects/assets/obscure-tooltips/1.21/obscure_tooltips/lang/zh_cn.json
+++ b/projects/assets/obscure-tooltips/1.21/obscure_tooltips/lang/zh_cn.json
@@ -1,0 +1,8 @@
+{
+  "rarity.common": "常见",
+  "rarity.uncommon": "少见",
+  "rarity.rare": "稀有",
+  "rarity.epic": "史诗",
+  "toast.obscure_tooltips.hint_1": "启用内置%s资源包",
+  "toast.obscure_tooltips.hint_2": "它包含动画效果和样式！"
+}


### PR DESCRIPTION
### 修改内容：
1. 适配1.20版本命名空间变更为 `obscure_tooltips`，替换原有旧的 `minecraft` 命名空间下的内容
2. 新增1.21版本翻译文件，使用新的 `obscure_tooltips` 命名空间
3. 按照打包器"完全复用"规则，为 `1.20-fabric` 和 `1.21-fabric` 版本配置复用策略，直接复用对应非fabric版本的翻译内容